### PR TITLE
fix: remove missing root export

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "Chand Rajendra-Nicolucci <chand@dashkite.com>"
   ],
   "exports": {
-    ".": {
-      "browser": "./build/browser/src/index.js",
-      "node": "./build/node/src/index.js"
-    },
     "./atomic": {
       "browser": "./build/browser/src/models/atomic.js",
       "node": "./build/node/src/models/atomic.js"


### PR DESCRIPTION
## Summary
- remove the root export entry that points to non-existent `build/*/src/index.js` files
- keep the concrete subpath exports (`./atomic`, `./composite`, `./value`, and `./mixins/*`) unchanged

## Why
The published `@dashkite/addison@0.2.31` tarball does not include a root `index.js` build for either Node or browser, but `package.json` advertises both:

```json
".": {
  "browser": "./build/browser/src/index.js",
  "node": "./build/node/src/index.js"
}
```

The tarball does include the concrete model/value/mixin files, and those subpath exports resolve to files that exist. The root entry is the stale one.

Repro from the npm tarball:

```sh
npm pack @dashkite/addison@0.2.31
# no build/node/src/index.js and no build/browser/src/index.js
node --input-type=module -e "import('@dashkite/addison')"
# ERR_MODULE_NOT_FOUND: Cannot find module .../node_modules/@dashkite/addison/build/node/src/index.js
```

## Validation
- parsed `package.json`
- checked `@dashkite/addison@0.2.31` tarball lacks both root index paths
- checked remaining concrete subpath targets exist in the tarball
- `git diff --check`